### PR TITLE
FLIGHT-481 Kickback - Fix mo-dep popup alignment

### DIFF
--- a/modules/views/components/Popup.js
+++ b/modules/views/components/Popup.js
@@ -76,10 +76,14 @@ define([
             var $el = this.$el;
             $el.show();
             rAF.setup(function () {
-                $el.css(params.css || {
-                    top: env.vkontakte ? 200 - $el.height() / 2 : ($(window).height() - $el.height()) / 2,
-                    left: ($('.ui-page-active').width() - $el.width()) / 2
-                });
+                var defaultCss = {
+                    top: env.vkontakte ? 200 : '50%',
+                    left: '50%',
+                    transform: 'translate(-50%, -50%)',
+                    '-webkit-transform': 'translate(-50%, -50%)'
+                };
+
+                $el.css(params.css || defaultCss);
 
                 $el.removeClass('min');
             });


### PR DESCRIPTION
This fixes the [kickback on FLIGHT-481](https://amstl.atlassian.net/browse/FLIGHT-481?focusedCommentId=222055) and should close the ticket as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved popup positioning by transitioning to CSS transform-based centering instead of dynamic height calculations. This enhances placement reliability and visual consistency across different environments while maintaining existing display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->