### PR TITLE
Add popup.dismiss(key) to remove a dialog by key

### DIFF
--- a/modules/popup.js
+++ b/modules/popup.js
@@ -11,7 +11,8 @@ define([
         isFrozen = false,
         frozenTypes = ['dark', 'award-unlocked'],
         hideTimeout = null,
-        hideCallback = null;
+        hideCallback = null,
+        currentParams = null;
 
     function init ($el) {
         view = new View($el);
@@ -31,6 +32,7 @@ define([
         }
 
         isShown = true;
+        currentParams = params;
 
         hideCallback = params.onHide || null;
 
@@ -70,12 +72,34 @@ define([
         view.clear(function () {
             isShown = false;
             isHiding = false;
+            currentParams = null;
             hideCallback && hideCallback();
 
             if (sequence.length) {
                 show(sequence.shift());
             }
         });
+    }
+
+    // Remove a dialog identified by params.dismissKey, whether it's on screen or still
+    // waiting in the queue. Rejects its dialog() promise so awaiting callers unwind.
+    function dismiss (key) {
+        if (!key) {
+            return;
+        }
+
+        sequence = sequence.filter(function (params) {
+            if (params.dismissKey === key) {
+                params.deferred && params.deferred.reject();
+                return false;
+            }
+            return true;
+        });
+
+        if (isShown && currentParams && currentParams.dismissKey === key) {
+            currentParams.deferred && currentParams.deferred.reject();
+            hide();
+        }
     }
 
     function castParams (params) {
@@ -159,7 +183,8 @@ define([
             type: 'dark',
             modal: true,
             buttons: buttons,
-            hideTimeout: null
+            hideTimeout: null,
+            deferred: deferred
         }, params));
 
         return deferred.promise();
@@ -185,6 +210,7 @@ define([
         blink: blink,
         bubble: bubble,
         dialog: dialog,
+        dismiss: dismiss,
         freeze: freeze,
         unfreeze: unfreeze,
         isShown: function () {


### PR DESCRIPTION
Adds `popup.dismiss(key)` so a caller can tag a dialog with `params.dismissKey` and later remove it — whether it's currently on screen or still waiting in the queue — rejecting its `dialog()` promise so any awaiting caller unwinds cleanly.

Needed by FlightcallClients (FLIGHT-510): a stale "Start tracking?" prompt must be pulled once the call finishes, even if it's queued behind another popup.

- `dialog()` now stores its `deferred` on the shown params so `dismiss` can settle it.
- Tracks `currentParams` to know if the on-screen dialog matches the key.
- No behavior change for existing callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to dismiss popups programmatically using a matching key.
  * Pending and visible dialogs with the same key are now closed and their waiting actions are cancelled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->